### PR TITLE
add compatibility report

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -106,5 +106,9 @@ Visit http://localhost:8000 for the report.
 
 ### 使用别的编程语言使用此工具
 本项目的主要工作是我们在 `cts.json`中增加了超过 7000 行测试，如果您希望用别的编程语言（例如 Java, Go, Rust等）实现相同功能的测试工具，那么您只需要解析 `cts.json` 的格式，并且将测试依次执行即可，玩的愉快。
+
+## 版本升级兼容性指南
+如果您正在计划升级 Redis 版本，我们建议您查阅这份 **[兼容性报告](compatibility_report_en_US.md)**。该报告梳理了 Redis 大版本之间的破坏性改动以及一些重要 Bug 的修复情况，旨在帮助您快速评估版本升级的风险，并提前规避已知问题。
+
 ## License
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -109,5 +109,9 @@ Overall, it is a JSON array, containing multiple test cases, each of which is a 
 ### Test with another programming language
 The main work of this project is that we have added more than 7000 lines of tests in `cts.json`, if you want to implement tests in other programming languages (such as Java, Go, Rust, etc.), then you only need to parse `cts.json ` format, and execute the tests sequentially, have fun.
 
+## Upgrade Compatibility Guide
+
+Planning a major version upgrade? To prevent unexpected issues, please check our **[Compatibility Report](compatibility_report_en_US.md)** for a list of breaking changes and important bug fixes.
+
 ## License
 [MIT](LICENSE)

--- a/compatibility_report_en_US.md
+++ b/compatibility_report_en_US.md
@@ -1,0 +1,425 @@
+# Redis Major Version Compatibility Report
+
+This document is compiled from the official Release Notes of the Redis community, insights from code reviews, and operational experience from the Alibaba Cloud Tair Team. It is intended to serve as a technical reference for Redis users to evaluate compatibility risks before undertaking major version upgrades. If you find any omissions, please open an issue to supplement this report. Accepted contributions will be acknowledged by adding your name to the list of contributors.
+
+# User-Facing Compatibility Differences
+
+## Upgrading from Version 4.0 to 5.0
+
+1.  **`KEYS` Command Behavior:** The `KEYS` command no longer actively deletes expired keys it encounters during traversal; it only skips them. It can no longer be used as a mechanism for active expiration. The `SCAN` command, however, retains its behavior of deleting expired keys it finds.
+    -   PR: [https://github.com/redis/redis/commit/edc47a3a](https://github.com/redis/redis/commit/edc47a3a)
+
+2.  **Lua Script Replication:** Lua scripts now default to effect replication (replicating the resulting commands) instead of script replication. This change prevents data divergence between primary and replica instances. This behavior can be reverted by modifying the `lua-replicate-commands` configuration (removed in 7.0) or using the `DEBUG lua-always-replicate-commands` command.
+    -   PR: [https://github.com/redis/redis/commit/3e1fb5ff](https://github.com/redis/redis/commit/3e1fb5ff)
+
+    ```plaintext
+    // 1. Non-deterministic commands can yield different results.
+    local key = KEYS[1]
+    local member = redis.call('SPOP', key)
+    redis.call('SET', 'last_removed', member)
+    return member
+
+    // 2. Different execution paths due to expiration/eviction.
+    local key = KEYS[1]
+    local value = redis.call('GET', key)
+    if value then
+        redis.call('SET', key, tonumber(value) + 1)
+    else
+        redis.call('SET', key, 1)
+    end
+    ```
+
+3.  **Read-only Script Replication:** Read-only scripts are now replicated as `SCRIPT LOAD` commands, not `EVAL`.
+    -   PR: [https://github.com/redis/redis/commit/dfbce91a](https://github.com/redis/redis/commit/dfbce91a)
+
+4.  **Replica `maxmemory` Policy:** Replicas now ignore the `maxmemory` setting by default and will not perform data eviction. The previous behavior can be restored by setting `replica-ignore-maxmemory` to `no`.
+    -   PR: [https://github.com/redis/redis/commit/447da44d](https://github.com/redis/redis/commit/447da44d)
+
+5.  **Shared Object Consistency:** When the `volatile-lru` eviction policy is active, Redis avoids using shared integer objects to ensure accurate LRU metadata. However, replicas loading an RDB file during a full sync did not apply this logic, resulting in the use of shared objects. This caused a memory representation mismatch where replicas consumed less memory than the primary for the same dataset. This has been fixed in Redis 5.0. After upgrading, you may observe that replica memory usage increases to match the primary's.
+    -   MRs:
+        -   [https://github.com/redis/redis/commit/bd92389c2dc1afcf53218880fc31ba45e66f4ded](https://github.com/redis/redis/commit/bd92389c2dc1afcf53218880fc31ba45e66f4ded)
+        -   [https://github.com/redis/redis/commit/0ed0dc3c02dfffdf6bfb9e32f1335ddc34f37723](https://github.com/redis/redis/commit/0ed0dc3c02dfffdf6bfb9e32f1335ddc34f37723)
+
+## Upgrading from Version 5.0 to 6.0
+
+1.  **`OBJECT ENCODING` for Stream:** The `OBJECT ENCODING` command now correctly returns the encoding type for stream, instead of "unknown."
+    -   PR: [https://github.com/redis/redis/pull/7797](https://github.com/redis/redis/pull/7797)
+
+2.  **Read-only Transactions in Cluster:** In cluster mode, read-only transactions can now be executed on replicas instead of being redirected to the primary with a `MOVED` error.
+    -   PR: [https://github.com/redis/redis/pull/7766](https://github.com/redis/redis/pull/7766)
+
+    ```plaintext
+    // Previous Behavior:
+    connect to a replica in cluster
+    > readonly
+    > get k
+    "v"
+    > multi
+    > get k
+    > exec
+    (error) MOVED
+
+    // New Behavior:
+    connect to a replica in cluster
+    > readonly
+    > get k
+    "v"
+    > multi
+    > get k
+    > exec
+    "v"
+    ```
+
+3.  **Blocking Command Timeout Precision:** The `timeout` parameter for `BRPOP`, `BLPOP`, and `BRPOPLPUSH` was changed from an integer (seconds) to a float number (seconds). This introduced a bug where a timeout value less than or equal to 0.001 seconds was parsed as 0, causing an indefinite block. This bug was fixed in Redis 7.0.
+    -   Docs: [https://redis.io/docs/latest/commands/brpop/](https://redis.io/docs/latest/commands/brpop/), [https://redis.io/docs/latest/commands/blpop/](https://redis.io/docs/latest/commands/blpop/), [https://redis.io/docs/latest/commands/brpoplpush/](https://redis.io/docs/latest/commands/brpoplpush/)
+
+4.  **Blocking Pop Timeout Precision:** The `timeout` parameter for `BZPOPMIN` and `BZPOPMAX` was also changed from an integer to a float, introducing the same indefinite block bug for small timeout values, which was fixed in 7.0.
+    -   Docs: [https://redis.io/docs/latest/commands/bzpopmin/](https://redis.io/docs/latest/commands/bzpopmin/), [https://redis.io/docs/latest/commands/bzpopmax/](https://redis.io/docs/latest/commands/bzpopmax/)
+
+5.  **String Length Limits:** The maximum string size for `SETRANGE` and `APPEND` is now determined by the `proto_max_bulk_len` configuration (default 512MB), rather than a hardcoded 512MB limit.
+    -   PR: [https://github.com/redis/redis/pull/4633](https://github.com/redis/redis/pull/4633)
+
+## Upgrading from Version 6.0 to 6.2
+
+1.  **AOF `fsync=always` Error Handling:** When `appendfsync` is set to `always`, a failed `fsync` operation will now cause the Redis process to terminate immediately.
+    -   PR: [https://github.com/redis/redis/pull/8347](https://github.com/redis/redis/pull/8347)
+
+2.  **Command Latency Statistics:** Latency statistics now include the time a command spends blocked, which affects `INFO commandstats`, `LATENCY` commands and `SLOWLOG` commands outputs.
+    -   PR: [https://github.com/redis/redis/pull/7491](https://github.com/redis/redis/pull/7491)
+
+3.  **`SRANDMEMBER` RESP3 Return Type:** The RESP3 return type for `SRANDMEMBER` has been changed from a Set to an Array to accommodate duplicate elements, which can be returned when a negative `count` is provided.
+    -   PR: [https://github.com/redis/redis/pull/8504](https://github.com/redis/redis/pull/8504)
+
+4.  **`PUBSUB NUMPAT` Return Value:** The meaning of the value returned by `PUBSUB NUMPAT` has changed. It now returns the count of unique subscribed patterns, whereas previously it returned the total number of subscribed clients for all patterns.
+    -   PR: [https://github.com/redis/redis/pull/8472](https://github.com/redis/redis/pull/8472)
+    -   Doc: [https://redis.io/docs/latest/commands/pubsub-numpat/](https://redis.io/docs/latest/commands/pubsub-numpat/)
+
+5.  **`CLIENT TRACKING` with Overlapping Prefixes:** `CLIENT TRACKING` now returns an error if a client attempts to track overlapping prefixes, which prevents duplicate invalidation messages.
+    -   PR: [https://github.com/redis/redis/pull/8176](https://github.com/redis/redis/pull/8176)
+
+6.  **`SWAPDB` and `WATCH`:** The `SWAPDB` command now touches all keys being watched in both of the swapped databases, causing any transactions watching those keys to fail.
+    -   PR: [https://github.com/redis/redis/pull/8239](https://github.com/redis/redis/pull/8239)
+
+    ```plaintext
+    // Previous Behavior: Transaction succeeds
+    client A> select 0
+    client A> set k 0
+    client A> select 1
+    client A[1]> set k 1
+    client A[1]> watch k
+    client A[1]> multi
+    client A[1]> get k
+
+    client B> swapdb 0 1
+
+    client A[1]> exec
+    "0"
+
+    // New Behavior: Transaction fails
+    client A> select 0
+    client A> set k 0
+    client A> select 1
+    client A[1]> set k 1
+    client A[1]> watch k
+    client A[1]> multi
+    client A[1]> get k
+
+    client B> swapdb 0 1
+
+    client A[1]> exec
+    (nil)
+    ```
+
+7.  **`FLUSHDB` and Client Tracking:** `FLUSHDB` now invalidates all keys for all clients that have tracking enabled.
+    -   PR: [https://github.com/redis/redis/pull/8039](https://github.com/redis/redis/pull/8039)
+
+8.  **BIT ops Length Limit:** The maximum result size for bit ops is now controlled by `proto_max_bulk_len` (default 512MB), not a hardcoded 512MB limit.
+    -   PR: [https://github.com/redis/redis/pull/8096](https://github.com/redis/redis/pull/8096)
+
+9.  **`bind` Configuration Syntax:** A `-` prefix on an IP address in the `bind` directive now signifies that an `EADDRNOTAVAIL` error for that address should be ignored. Without the prefix, such an error on a non-default address will cause startup to fail. Additionally, `bind *` is now supported as an explicit way to bind to all available network interfaces.
+    -   PR: [https://github.com/redis/redis/pull/7936](https://github.com/redis/redis/pull/7936)
+
+    ```plaintext
+    // Previous Behavior:
+    Any bind failure was ignored as long as at least one succeeded.
+
+    // New Behavior:
+    Binding to the default address (127.0.0.1/::1) will not affect Redis startup if at least one address succeeds.
+    Binding to a non-default address (e.g., -192.168.1.100) with a '-' prefix will not affect Redis startup if the address fails to bind. Failure to bind to the non-default address without the '-' prefix will cause Redis startup to fail.
+    ```
+
+10. **`save` Configuration with Command-Line Arguments:** Launching `redis-server` with parameters no longer resets the `save` configuration. Previously, using additional parameters, regardless of whether `save` was included, would cause the save configuration to be reset to "" before loading other additional parameters.
+    -   PR: [https://github.com/redis/redis/pull/7092](https://github.com/redis/redis/pull/7092)
+
+    ```plaintext
+    // Previous Behavior:
+    redis-server --other-args xx                   --> save ""
+    redis-server [--other-args xx] --save 3600 1   --> save "3600 1"
+    redis-server                                   --> save "3600 1 300 100 60 10000"
+
+    // New Behavior:
+    redis-server --other-args xx                   --> save "3600 1 300 100 60 10000"
+    redis-server [--other-args xx] --save 3600 1   --> save "3600 1"
+    redis-server                                   --> save "3600 1 300 100 60 10000"
+    ```
+
+11. **`SLOWLOG` Command Representation:** `SLOWLOG` now records the original command as executed by the client, not the rewritten version (e.g., `SPOP` is logged as `SPOP`, not `DEL`).
+    -   PR: [https://github.com/redis/redis/pull/8006](https://github.com/redis/redis/pull/8006)
+
+## Upgrading from Version 6.2 to 7.0
+
+1.  **Lua Script Replication Finalized:** Lua scripts are definitively no longer persisted or replicated. The `SCRIPT LOAD` and `SCRIPT FLUSH` commands are also no longer replicated, and the `lua-replicate-commands` configuration has been removed. Effect replication is now the only mode.
+    -   PR: [https://github.com/redis/redis/pull/9812](https://github.com/redis/redis/pull/9812)
+
+2.  **Synchronous Shutdown:** A shutdown initiated by `SHUTDOWN`, `SIGTERM`, or `SIGINT` now waits for replicas to catch up on replication, with a timeout defined by `shutdown-timeout` (default 10 seconds).
+    -   PR: [https://github.com/redis/redis/pull/9872](https://github.com/redis/redis/pull/9872)
+    -   Command Doc: [https://redis.io/docs/latest/commands/shutdown/](https://redis.io/docs/latest/commands/shutdown/)
+
+3.  **ACL Default Channel Permissions:** The default user's channel permissions have been changed from `allchannels` to `resetchannels`, effectively disabling all Pub/Sub commands by default until explicitly permitted.
+    -   PR: [https://github.com/redis/redis/pull/10181](https://github.com/redis/redis/pull/10181)
+
+4.  **`ACL LOAD` with Duplicate Users:** `ACL LOAD` now returns an error if the loaded configuration contains duplicate user definitions, instead of silently applying the last one.
+    -   PR: [https://github.com/redis/redis/pull/9330](https://github.com/redis/redis/pull/9330)
+
+5.  **Expiration Replication:** Key expiration times are now always replicated as absolute millisecond-precision timestamps.
+    -   PR: [https://github.com/redis/redis/pull/8474](https://github.com/redis/redis/pull/8474)
+
+6.  **`STRALGO` Command Removed:** The `STRALGO` command has been removed and its functionality promoted to the top-level `LCS` command.
+    -   PR: [https://github.com/redis/redis/pull/9799](https://github.com/redis/redis/pull/9799)
+    -   Doc: [https://redis.io/docs/latest/commands/lcs/](https://redis.io/docs/latest/commands/lcs/)
+
+7.  **New Security Configuration:** Three new immutable startup configurations have been added: `enable-protected-configs`, `enable-debug-command`, and `enable-module-command`. All default to `no`, providing a more secure-by-default posture by disabling runtime changes to protected configs and access to `DEBUG` and `MODULE` commands.
+    -   PR: [https://github.com/redis/redis/pull/9920](https://github.com/redis/redis/pull/9920)
+
+8.  **Transaction Command Restrictions:** `SAVE`, `PSYNC`, `SYNC`, and `SHUTDOWN` are now prohibited inside a `MULTI`/`EXEC` block. `BGSAVE`, `BGREWRITEAOF`, and `CONFIG SET appendonly` are deferred until after the transaction executes.
+    -   PR: [https://github.com/redis/redis/pull/10015](https://github.com/redis/redis/pull/10015)
+
+9.  **`ZPOPMIN`/`ZPOPMAX` Error Handling:** These commands now return a `WRONGTYPE` error for non-sorted-set keys and an error for a negative `count`, instead of returning an empty array.
+    -   PR: [https://github.com/redis/redis/pull/9711](https://github.com/redis/redis/pull/9711)
+
+10. **`CONFIG REWRITE` and Modules:** `CONFIG REWRITE` now persists currently loaded modules to the configuration file using `loadmodule` directives.
+    -   PR: [https://github.com/redis/redis/pull/4848](https://github.com/redis/redis/pull/4848)
+
+11. **`X[AUTO]CLAIM` for Deleted Messages:** `XCLAIM` and `XAUTOCLAIM` now handle cases where a pending message has been deleted from the stream. Instead of returning `nil`, they now remove the message from the Pending Entries List (PEL). `XAUTOCLAIM` also returns a list of deleted message IDs.
+    -   PR: [https://github.com/redis/redis/pull/10227](https://github.com/redis/redis/pull/10227)
+    -   Docs: [https://redis.io/docs/latest/commands/xclaim/](https://redis.io/docs/latest/commands/xclaim/), [https://redis.io/docs/latest/commands/xautoclaim/](https://redis.io/docs/latest/commands/xautoclaim/)
+
+    ```plaintext
+    // Previous Behavior:
+    > XADD x 1 f1 v1
+    "1-0"
+    > XADD x 2 f1 v1
+    "2-0"
+    > XADD x 3 f1 v1
+    "3-0"
+    > XGROUP CREATE x grp 0
+    OK
+    > XREADGROUP GROUP grp Alice COUNT 2 STREAMS x >
+    1) 1) "x"
+       2) 1) 1) "1-0"
+             2) 1) "f1"
+                2) "v1"
+          2) 1) "2-0"
+             2) 1) "f1"
+                2) "v1"
+    > XDEL x 1 2
+    (integer) 2
+    > XCLAIM x grp Bob 0 0-99 1-0 1-99 2-0
+    1) (nil)
+    2) (nil)
+    > XPENDING x grp
+    1) (integer) 2
+    2) "1-0"
+    3) "2-0"
+    4) 1) 1) "Bob"
+          2) "2"
+
+    // New Behavior:
+    > Same until XDEL
+    > XCLAIM x grp Bob 0 0-99 1-0 1-99 2-0
+    (empty array)
+    > XPENDING x grp
+    1) (integer) 0
+    2) (nil)
+    3) (nil)
+    4) (nil)
+    ```
+
+12. **`XREADGROUP` Unblocking:** A client blocked on `XREADGROUP` will now be unblocked if the target stream key is deleted.
+    -   PR: [https://github.com/redis/redis/pull/10306](https://github.com/redis/redis/pull/10306)
+
+13. **`SORT` with `BY`/`GET` Permissions:** `SORT` and `SORT_RO` now require read permissions for all external keys referenced via `BY` or `GET` patterns.
+    -   PR: [https://github.com/redis/redis/pull/10340](https://github.com/redis/redis/pull/10340)
+
+14. **Replica Persistence Errors:** A replica will now panic and exit if it fails to do persistence operations, preventing it from continuing with a potentially diverged dataset. Set `replica-ignore-disk-write-errors yes` to restore the old behavior (default is no).
+    -   PR: [https://github.com/redis/redis/pull/10504](https://github.com/redis/redis/pull/10504)
+
+15. **Lua `print` Function Removed:** The `print()` function in Lua scripts is removed. Use `redis.log(...)` for logging.
+    -   PR: [https://github.com/redis/redis/pull/10651](https://github.com/redis/redis/pull/10651)
+
+16. **Read-only Script Command Restrictions:** `PFCOUNT` and `PUBLISH` are now disallowed in read-only scripts, as they can have side effects that must be replicated.
+    -   PR: [https://github.com/redis/redis/pull/10744](https://github.com/redis/redis/pull/10744)
+
+17. **Subcommand Statistics:** Command statistics are now tracked at the subcommand level. For example, `INFO commandstats` will show separate entries for `CLIENT LIST` and `CLIENT TRACKING` instead of a single entry for `CLIENT`.
+    -   PR: [https://github.com/redis/redis/pull/9504](https://github.com/redis/redis/pull/9504)
+
+18. **Multi-Part AOF:** A new AOF format has been introduced. The AOF is now stored as a directory (path configured by `appenddirname`) containing a manifest, a base AOF file, and incremental AOF files.
+    -   PR: [https://github.com/redis/redis/pull/9788](https://github.com/redis/redis/pull/9788)
+
+## Upgrading from Version 7.0 to 7.2
+
+1.  **Client Tracking in Lua Scripts:** When Client Tracking is enabled, tracking is now based on the keys actually accessed by commands within a Lua script, rather than all keys declared in the `EVAL` call.
+    -   PR: [https://github.com/redis/redis/pull/11770](https://github.com/redis/redis/pull/11770)
+
+    ```plaintext
+    // Previous Behavior: Tracks all declared keys
+    client A> CLIENT TRACKING on
+    client A> EVAL "redis.call('get', 'key2')" 2 key1 key2
+
+    client B> MSET key1 1 key2 2
+
+    client A> -> invalidate: 'key1'
+    client A> -> invalidate: 'key2'
+
+    // New Behavior: Tracks only accessed keys
+    client A> CLIENT TRACKING on
+    client A> EVAL "redis.call('get', 'key2')" 2 key1 key2
+
+    client B> MSET key1 1 key2 2
+
+    client A> -> invalidate: 'key2'
+    ```
+
+2.  **Time Caching within Commands:** Command execution now uses a "time snapshot." The server time is cached at the beginning of a command's execution (or a Lua script) and remains constant throughout. A typical example is that you cannot wait for a key to expire in a Lua script.
+    -   PR: [https://github.com/redis/redis/pull/10300](https://github.com/redis/redis/pull/10300)
+
+3.  **ACL Verbosity:** ACL now records all permission modifications, even redundant ones. This affects the output of `ACL SAVE`, `ACL GETUSER`, and `ACL LIST`.
+    -   PR: [https://github.com/redis/redis/pull/11224](https://github.com/redis/redis/pull/11224)
+
+4.  **Stream Consumer Creation:** `XREADGROUP` and `X[AUTO]CLAIM` now create a consumer in the consumer group even if no messages are successfully read or claimed.
+    -   PR: [https://github.com/redis/redis/pull/11099](https://github.com/redis/redis/pull/11099)
+
+5.  **Stream Consumer Idle Time:** When the XREADGROUP command does not read any message, it resets the idle field of the consumer and adds the active-time field to record the time when the consumer last successfully read a message.
+    -   PR: [https://github.com/redis/redis/pull/11099](https://github.com/redis/redis/pull/11099)
+
+6.  **Re-checking on Unblocking:** When a client unblocks from a blocking command, security and resource limit checks (e.g., ACL, OOM) are performed again before the command proceeds.
+    -   PR: [https://github.com/redis/redis/pull/11012](https://github.com/redis/redis/pull/11012)
+
+    ```plaintext
+    // Previous Behavior:
+    // Check ACL/OOM -> Block -> Unblock -> Execute
+
+    // New Behavior:
+    // Check ACL/OOM -> Block -> Unblock -> Re-check ACL/OOM -> Execute
+    ```
+
+# Important Bugfixes
+
+## Version 5.0
+
+1.  **UAF Crash on Key Expiration:** Fixed a critical Use-After-Free (UAF) vulnerability where a key could expire and be deleted during command execution, leading to a server crash. (Affects 4.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/68d71d83](https://github.com/redis/redis/commit/68d71d83)
+
+2.  **AOF `everysec` Data Loss:** Fixed a bug when the AOF flushing policy is set to everysec, data within the last second may not be flushed to disk, resulting in data loss. (Affects 4.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/c6b1252f](https://github.com/redis/redis/commit/c6b1252f)
+
+3.  **Transaction Error Stats:** Fixed a bug where errors from commands within a transaction were incorrectly attributed to the `EXEC` command in command statistics. (Affects 4.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/d6aeca86](https://github.com/redis/redis/commit/d6aeca86)
+
+## Version 6.0
+
+1.  **`KEYS` Pattern with Null Byte:** Fixed a bug where a `KEYS` pattern starting with `\*\0` would match all keys in the database. (Backported to 5.0; affects 4.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/c7f75266](https://github.com/redis/redis/commit/c7f75266)
+
+2.  **Float Conversion with Null Byte:** String-to-float conversions now correctly fail if the string contains a null byte (`\0`). This affects commands like `HINCRBYFLOAT`. (Affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/6fe55c2f](https://github.com/redis/redis/commit/6fe55c2f)
+
+3.  **`-READONLY` Error in Transactions:** A `-READONLY` error within a transaction now correctly aborts the transaction. (Affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/commit/8783304a](https://github.com/redis/redis/commit/8783304a)
+
+## Version 6.2
+
+1.  **`EXISTS`/`OBJECT` and LRU:** `EXISTS` no longer modifies a key's LRU value, and `OBJECT` no longer returns information for expired keys. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8016](https://github.com/redis/redis/pull/8016)
+
+2.  **Hash Table Sampling Fairness:** Fixed a 32-bit limitation in random element sampling from hash tables, which impacted the fairness of eviction and commands like `RANDOMKEY` and `SRANDMEMBER` on large hashes. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8133](https://github.com/redis/redis/pull/8133)
+
+3.  **`SMOVE` Notifications:** `SMOVE` no longer generates `WATCH` or `CLIENT TRACKING` notifications if the move is a no-op. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9244](https://github.com/redis/redis/pull/9244)
+
+4.  **Pipeline Stall after Lua Timeout:** Fixed an issue where a timed-out Lua script in a pipeline could cause the server to stop processing subsequent commands from that client until new data arrived. (Affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8715](https://github.com/redis/redis/pull/8715)
+
+5.  **`SCRIPT KILL` and `pcall`:** `SCRIPT KILL` can now successfully terminate a script that is inside a `pcall` block. (Affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8661](https://github.com/redis/redis/pull/8661)
+
+
+## Version 7.0
+
+1.  **Lua Stack Overflow:** Fixed an assertion failure caused by a stack overflow when passing an extremely large number of arguments to a Lua script. (Backported to 6.0; affects 5.0)
+    -   PR: [https://github.com/redis/redis/pull/9809](https://github.com/redis/redis/pull/9809)
+
+2.  **`list-compress-depth` Crash:** Fixed a potential crash when using the `list-compress-depth` configuration. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9849](https://github.com/redis/redis/pull/9849)
+
+3.  **RDB Corruption with Large Items:** Fixed RDB file corruption when `rdbcompression` is enabled and the RDB contains a String or List value larger than 4GB. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9776](https://github.com/redis/redis/pull/9776)
+
+4.  **Crash on Large Set/Hash Elements:** Fixed a crash when adding an element larger than 2GB to a Set or Hash. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9916](https://github.com/redis/redis/pull/9916)
+
+5.  **Expiration Time Overflow:** Setting an extremely large or small expiration time now returns an error instead of causing an integer overflow. (Backported to 6.2; affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8287](https://github.com/redis/redis/pull/8287)
+
+6.  **`DECRBY` with `LLONG_MIN`:** `DECRBY` now returns an error when the decrement value is `LLONG_MIN`, preventing an integer overflow. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9577](https://github.com/redis/redis/pull/9577)
+
+7.  **ZSet Rank Overflow:** Fixed a potential rank calculation overflow in sorted sets with more than `UINT32_MAX` elements. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9249](https://github.com/redis/redis/pull/9249)
+
+8.  **Lua and `CLIENT TRACKING NOLOOP`:** Fixed a bug where write commands executed within a Lua script would ignore the `CLIENT TRACKING NOLOOP` option. (Affects 6.0)
+    -   PR: [https://github.com/redis/redis/pull/11052](https://github.com/redis/redis/pull/11052)
+
+9.  **`CLIENT TRACKING` Message Interleaving:** Fixed a bug where client tracking invalidation messages could be interleaved with the replies of other commands on the same connection. (Backported to 6.2; affects 6.0)
+    -   PRs: [https://github.com/redis/redis/pull/11038](https://github.com/redis/redis/pull/11038), [https://github.com/redis/redis/pull/9422](https://github.com/redis/redis/pull/9422)
+
+10. **`WATCH` and Expired Keys:** A transaction now fails if a `WATCH`ed key has expired by the time of `EXEC`, regardless of whether it has been actively deleted. In addition, during the execution of a transaction, the timestamp used by the server to determine whether it has expired should not be updated. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9194](https://github.com/redis/redis/pull/9194)
+
+11. **`SINTERSTORE` Type Errors:** Fixed a bug where `SINTERSTORE` failed to return a `WRONGTYPE` error and could delete the destination key when operating on incorrect types. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9032](https://github.com/redis/redis/pull/9032)
+
+12. **Client Buffer Soft Limit Timeout:** Fixed a bug where a client exceeding a `client-output-buffer-limit` soft limit would not be disconnected after the timeout if it remained idle. (Backported to 6.2; affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/8833](https://github.com/redis/redis/pull/8833)
+
+13. **Stream Keyspace Notifications:** Fixed bugs where stream commands for consumer management did not emit or incorrectly emitted keyspace notifications. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/9263](https://github.com/redis/redis/pull/9263)
+
+14. **`GEO` Search Boundary Bug:** Fixed a bug in `GEO` search commands that could cause them to miss elements located very close to the search radius boundary. (Affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/10018](https://github.com/redis/redis/pull/10018)
+
+15. **Lua Metatable Error Crash:** Fixed a server crash that could occur if an error was triggered while processing a Lua return value that involved a metatable. (Affects 6.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/11032](https://github.com/redis/redis/pull/11032)
+
+16. **Blocking Command Indefinite Block:** Fixed the bug where blocking commands with timeouts could block indefinitely if the timeout was less than 0.001 seconds. (Affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/11688](https://github.com/redis/redis/pull/11688)
+
+17. **Denial of Service via Random Commands:** Fixed vulnerabilities where maliciously crafted `KEYS`, `HRANDFIELD`, `SRANDMEMBER`, and `ZRANDMEMBER` commands could cause the server to hang. (`KEYS` may still causes a hang in 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/11676](https://github.com/redis/redis/pull/11676)
+
+18. **Lua Global Variable Security:** As a security enhancement, creating global variables in Lua scripts is now prohibited. All variables must be declared with `local`. Scripts that violate this will now fail. (Backported to all supported versions, old scripts may report an error after upgrading)
+    -   PR: [https://github.com/redis/redis/pull/10651](https://github.com/redis/redis/pull/10651)
+
+## Version 7.2
+
+1.  **Random Command Infinite Loop:** Fixed a bug in `SRANDMEMBER`, `ZRANDMEMBER`, and `HRANDFIELD` where using the `count` argument had a small probability of causing an infinite loop. (Backported to 7.0; affects 6.2 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/12276](https://github.com/redis/redis/pull/12276)
+
+2.  **`HINCRBYFLOAT` Key Creation:** `HINCRBYFLOAT` no longer creates a hash key if the `increment` argument is not a valid float. (Backported to 6.0; affects 5.0 and earlier)
+    -   PR: [https://github.com/redis/redis/pull/11149](https://github.com/redis/redis/pull/11149)
+    -   Doc: [https://redis.io/docs/latest/commands/hincrbyfloat/](https://redis.io/docs/latest/commands/hincrbyfloat/)
+
+3.  **`LSET` Crash on Large Element Replacement:** Fixed a potential crash with `LSET` in extreme cases when replacing many small list elements with a large one. (Affects 7.0)
+    -   PR: [https://github.com/redis/redis/pull/12955](https://github.com/redis/redis/pull/12955)
+    -   Doc: [https://redis.io/docs/latest/commands/lset/](https://redis.io/docs/latest/commands/lset/)

--- a/compatibility_report_zh_CN.md
+++ b/compatibility_report_zh_CN.md
@@ -1,0 +1,431 @@
+# Redis 大版本兼容性报告
+
+本文档根据 Redis 社区的 Release Note 以及阿里云 Tair 团队阅读 Redis 代码和日常运营遇到的问题撰写，供 Redis 用户升级大版本前评估和参考。如有遗漏，欢迎提 issue 补充，采纳后会同时添加您到贡献者列表。
+
+# 用户视角兼容性差异：
+
+## 4.0 版本升级到 5.0 版本
+
+1.  `KEYS` 命令遍历过程中只跳过已过期的 key，不再删除。不能再使用 `KEYS` 命令来主动清理已过期的 key，`SCAN` 命令仍会删除扫描到的已过期数据。
+    -   社区 PR：[https://github.com/redis/redis/commit/edc47a3a](https://github.com/redis/redis/commit/edc47a3a)
+
+2.  Lua 脚本默认使用效果复制，而不再复制脚本本身，防止脚本在主备上执行结果不一致带来的数据不一致，可以通过配置项 `lua-replicate-commands` 更改（在 7.0 版本移除），或是 `DEBUG lua-always-replicate-commands` 命令更改。
+    -   社区 PR：[https://github.com/redis/redis/commit/3e1fb5ff](https://github.com/redis/redis/commit/3e1fb5ff)
+    
+    ```plaintext
+    1. 使用随机性命令，复制脚本会导致在主备上结果不同
+    local key = KEYS[1]
+    local member = redis.call('SPOP', key)
+    redis.call('SET', 'last_removed', member)
+    return member
+
+    2. 由于过期/逐出行为，导致 get 得到的结果在主备上不同，导致脚本在主备执行不同分支 
+    local key = KEYS[1]
+    local value = redis.call('GET', key)
+    if value then
+        redis.call('SET', key, tonumber(value) + 1)
+    else
+        redis.call('SET', key, 1)
+    end
+    ```
+
+3.  只读脚本会复制为 `SCRIPT LOAD` 命令，不再复制 `EVAL`。
+    -   社区 PR：[https://github.com/redis/redis/commit/dfbce91a](https://github.com/redis/redis/commit/dfbce91a)
+
+4.  备库默认忽略 `maxmemory` 限制，不再尝试逐出数据，可以通过配置项 `slave-ignore-maxmemory` 更改。
+    -   社区 PR：[https://github.com/redis/redis/commit/447da44d](https://github.com/redis/redis/commit/447da44d)
+
+5.  Redis 在开启 `volatile-lru` 内存逐出策略的时候，会禁止使用 `shared obj` 来表示诸如 1,2,3 等类似的数字（避免更新 LRU 信息的时候互相影响），副作用是浪费了内存。但是在主备复制时，如果走了全量复制，那么备库在加载 RDB 时没有复用那个策略，导致备库加载起来之后内存中的 key 使用了 `shared obj` 对象。因此这就会导致主备虽然数据一致，但是内存中的数据编码不一样。从而导致备库使用的内存比主库的小。该问题在 5.0 版本修复。升级后可能会遇到内存容量不一样的情况，社区 MR：
+    -   [https://github.com/redis/redis/commit/bd92389c2dc1afcf53218880fc31ba45e66f4ded](https://github.com/redis/redis/commit/bd92389c2dc1afcf53218880fc31ba45e66f4ded)
+    -   [https://github.com/redis/redis/commit/0ed0dc3c02dfffdf6bfb9e32f1335ddc34f37723](https://github.com/redis/redis/commit/0ed0dc3c02dfffdf6bfb9e32f1335ddc34f37723)
+
+## 5.0 版本升级到 6.0 版本
+
+1.  `OBJECT ENCODING` 命令支持识别并返回 stream 类型，原来对 stream 类型的数据使用 `OBJECT ENCODING` 命令会错误返回 "unknown"。
+    -   社区 PR：[https://github.com/redis/redis/pull/7797](https://github.com/redis/redis/pull/7797)
+
+2.  集群模式下，只读事务允许在只读节点上执行，而不是重定向到主节点。
+    -   社区 PR：[https://github.com/redis/redis/pull/7766](https://github.com/redis/redis/pull/7766)
+    
+    ```plaintext
+    原来的行为：
+    connect to a replica in cluster
+    > readonly
+    > get k
+    "v"
+    > multi
+    > get k
+    > exec
+    (error) MOVED
+
+    改动后：
+    connect to a replica in cluster
+    > readonly
+    > get k
+    "v"
+    > multi
+    > get k
+    > exec
+    "v"
+    ```
+
+3.  `BRPOP`/`BLPOP`/`BRPOPLPUSH` timeout 参数由整数改为浮点数。引入了当 timeout 小于等于 0.001 秒时，会被解析为 0 导致永久阻塞的 bug，在 7.0 版本才修复。
+    -   命令文档：[https://redis.io/docs/latest/commands/brpop/](https://redis.io/docs/latest/commands/brpop/), [https://redis.io/docs/latest/commands/blpop/](https://redis.io/docs/latest/commands/blpop/), [https://redis.io/docs/latest/commands/brpoplpush/](https://redis.io/docs/latest/commands/brpoplpush/)
+
+4.  `BZPOPMIN`/`BZPOPMAX` timeout 参数由整数改为浮点数。引入了当 timeout 小于等于 0.001 秒时，会被解析为 0 导致永久阻塞的 bug，在 7.0 版本才修复。
+    -   命令文档：[https://redis.io/docs/latest/commands/bzpopmin/](https://redis.io/docs/latest/commands/bzpopmin/), [https://redis.io/docs/latest/commands/bzpopmax/](https://redis.io/docs/latest/commands/bzpopmax/)
+
+5.  `SETRANGE`, `APPEND` 命令所能生成的最大 string 类型长度由确定的 512MB 修改为使用配置 `proto_max_bulk_len` 控制（`proto_max_bulk_len` 默认值仍为 512MB）。
+    -   社区 PR：[https://github.com/redis/redis/pull/4633](https://github.com/redis/redis/pull/4633)
+
+## 6.0 版本升级到 6.2 版本
+
+1.  当 AOF fsync 的策略是 'always' 时，fsync 失败会直接让进程退出。
+    -   社区 PR：[https://github.com/redis/redis/pull/8347](https://github.com/redis/redis/pull/8347)
+
+2.  命令的执行时间统计包含 Block 的时间，影响 `INFO commandstats`、 `LATENCY` 族命令以及 `SLOWLOG` 族命令的统计。
+    -   社区 PR：[https://github.com/redis/redis/pull/7491](https://github.com/redis/redis/pull/7491)
+
+3.  将 `SRANDMEMBER` 命令在 RESP 3 协议下的返回值类型从 Set 改为 Array，因为当使用负数的 `COUNT` 参数时，可以允许执行结果包含重复元素。
+    -   社区 PR：[https://github.com/redis/redis/pull/8504](https://github.com/redis/redis/pull/8504)
+
+4.  `PUBSUB NUMPAT` 命令返回值含义改变，6.0 及以前版本返回的是所有 pattern 的订阅总数（客户端数量），6.2 版本开始返回 pattern 总数（pattern 数量）。
+    -   社区 PR：[https://github.com/redis/redis/pull/8472](https://github.com/redis/redis/pull/8472)
+    -   命令文档：[https://redis.io/docs/latest/commands/pubsub-numpat/](https://redis.io/docs/latest/commands/pubsub-numpat/)
+
+5.  `CLIENT TRACKING` 如果订阅了相互包含的前缀会返回错误，用于防止客户端收到重复的消息。
+    -   社区 PR：[https://github.com/redis/redis/pull/8176](https://github.com/redis/redis/pull/8176)
+
+6.  `SWAPDB` 命令会 touch 两个 DB 中的所有 watch keys，让事务失败。
+    -   社区 PR：[https://github.com/redis/redis/pull/8239](https://github.com/redis/redis/pull/8239)
+    
+    ```plaintext
+    原来的行为：
+    client A> select 0
+    client A> set k 0
+    client A> select 1
+    client A[1]> set k 1
+    client A[1]> watch k
+    client A[1]> multi
+    client A[1]> get k
+
+    client B> swapdb 0 1
+
+    client A[1]> exec
+    "0"
+
+    改动后：
+    client A> select 0
+    client A> set k 0
+    client A> select 1
+    client A[1]> set k 1
+    client A[1]> watch k
+    client A[1]> multi
+    client A[1]> get k
+
+    client B> swapdb 0 1
+
+    client A[1]> exec
+    (nil)
+    ```
+
+7.  `FLUSHDB` 会清除 server 上所有客户端的所有 tracking key 记录。
+    -   社区 PR：[https://github.com/redis/redis/pull/8039](https://github.com/redis/redis/pull/8039)
+
+8.  BIT 操作最大限制长度由确定的 512MB 修改为使用配置 `proto_max_bulk_len` 控制（`proto_max_bulk_len` 默认值仍为 512MB）。
+    -   社区 PR：[https://github.com/redis/redis/pull/8096](https://github.com/redis/redis/pull/8096)
+
+9.  `bind` 配置在启动 server 时需要指明 `-` 前缀，有 `-` 前缀的地址会自动忽略 `EADDRNOTAVAIL` 错误，否则不忽略；之前的版本默认会忽略 `EADDRNOTAVAIL` 错误。同时支持使用 `bind *` 来监听所有地址，之前的版本只能通过省略 `bind` 配置来实现。
+    -   社区 PR：[https://github.com/redis/redis/pull/7936](https://github.com/redis/redis/pull/7936)
+    
+    ```plaintext
+    原来的行为：
+    bind 任何地址，只要有一个地址成功，其它失败不会影响 Redis 启动
+
+    改动后：
+    bind 默认地址(127.0.0.1/::1)，只要有一个地址成功，其它失败不会影响 Redis 启动
+    bind 指定'-' + 非默认地址(如 -192.168.1.100)，该地址绑定失败不会影响 Redis 启动，不加'-'的非默认地址失败会导致 Redis 启动失败
+    ```
+
+10. 使用参数启动 `redis-server` 不再重置 `save` 配置，之前的版本只要使用了额外的参数，无论是否包括 `save`，就会导致 `save` 配置先被重置为 `""`，然后再加载其他额外参数。
+    -   社区 PR：[https://github.com/redis/redis/pull/7092](https://github.com/redis/redis/pull/7092)
+    
+    ```plaintext
+    原来的行为：
+    redis-server --other-args xx                   --> save ""
+    redis-server [--other-args xx] --save 3600 1   --> save "3600 1"
+    redis-server                                   --> save "3600 1 300 100 60 10000"
+
+    改动后：
+    redis-server --other-args xx                   --> save "3600 1 300 100 60 10000"
+    redis-server [--other-args xx] --save 3600 1   --> save "3600 1"
+    redis-server                                   --> save "3600 1 300 100 60 10000"
+    ```
+
+11. `SLOWLOG` 中记录原始命令而不是 rewrite 之后的命令。
+    -   社区 PR：[https://github.com/redis/redis/pull/8006](https://github.com/redis/redis/pull/8006)
+    
+    ```plaintext
+    原来的行为：
+    SPOP 等命令导致 key 删除/GEOADD/incrbyfloat 等命令如果被慢日志记录，记录的会是 rewrite 后的命令 DEL/ZADD/SET
+
+    改动后：
+    慢日志中始终展示的是真正执行（未经 rewrite 的）命令
+    ```
+
+## 6.2 版本升级到 7.0 版本
+
+1.  Lua 脚本不再进行持久化和复制。`SCRIPT LOAD`，`SCRIPT FLUSH` 也不再复制，`lua-replicate-commands` 配置移除，现在 Lua 确定进行效果复制。
+    -   社区 PR：[https://github.com/redis/redis/pull/9812](https://github.com/redis/redis/pull/9812)
+
+2.  `SHUTDOWN`/`SIGTERM`/`SIGINT` 触发的退出现在会等待 replica 同步最多 `shutdown-timeout` 秒。
+    -   社区 PR：[https://github.com/redis/redis/pull/9872](https://github.com/redis/redis/pull/9872)
+    -   命令文档：[https://redis.io/docs/latest/commands/shutdown/](https://redis.io/docs/latest/commands/shutdown/)
+
+3.  ACL 默认的 channel 权限从 `allchannels` 改为 `resetchannels`，默认禁止所有 channel 的 Pub/Sub。
+    -   社区 PR：[https://github.com/redis/redis/pull/10181](https://github.com/redis/redis/pull/10181)
+
+4.  ACL load 过程中如果有相同的用户，不再静默地以最后一条为准，现在会抛出错误。
+    -   社区 PR：[https://github.com/redis/redis/pull/9330](https://github.com/redis/redis/pull/9330)
+
+5.  过期时间永远以毫秒级绝对时间戳进行复制。
+    -   社区 PR：[https://github.com/redis/redis/pull/8474](https://github.com/redis/redis/pull/8474)
+
+6.  移除 `STRALGO` 命令，添加 `LCS` 作为一个独立的命令。
+    -   社区 PR：[https://github.com/redis/redis/pull/9799](https://github.com/redis/redis/pull/9799)
+    -   命令文档：[https://redis.io/docs/latest/commands/lcs/](https://redis.io/docs/latest/commands/lcs/)
+
+7.  增加了三个 immutable 配置 `enable-protected-configs`, `enable-debug-command`, `enable-module-command`, 默认值均为 no，分别默认禁止修改带有 `PROTECTED_CONFIG` 属性的配置，默认禁止使用 `DEBUG` 命令，默认禁止使用 `MODULE` 命令。
+    -   社区 PR：[https://github.com/redis/redis/pull/9920](https://github.com/redis/redis/pull/9920)
+
+8.  禁止 `SAVE`, `PSYNC`, `SYNC`, `SHUTDOWN` 命令在事务中执行；事务中的 `BGSAVE`, `BGREWRITEAOF`, `CONFIG SET appendonly` 命令会延迟到事务结束后进行。
+    -   社区 PR：[https://github.com/redis/redis/pull/10015](https://github.com/redis/redis/pull/10015)
+
+9.  `ZPOPMIN`, `ZPOPMAX` 命令当 key 的类型错误或输入的 count 参数为负数时，会返回错误而不是空数组。
+    -   社区 PR：[https://github.com/redis/redis/pull/9711](https://github.com/redis/redis/pull/9711)
+
+10. `CONFIG REWRITE` 命令会将已经加载的 module rewrite 为 `loadmodule` 写入文件中。
+    -   社区 PR：[https://github.com/redis/redis/pull/4848](https://github.com/redis/redis/pull/4848)
+
+11. `X[AUTO]CLAIM` 当消息已经被删除时，不再返回 nil，`XCLAIM` 会自动将已经删除的消息从 PEL 中移除，`XAUTOCLAIM` 的返回值会新增已删除消息 ID 列表。
+    -   社区 PR：[https://github.com/redis/redis/pull/10227](https://github.com/redis/redis/pull/10227)
+    -   命令文档：[https://redis.io/docs/latest/commands/xclaim/](https://redis.io/docs/latest/commands/xclaim/), [https://redis.io/docs/latest/commands/xautoclaim/](https://redis.io/docs/latest/commands/xautoclaim/)
+    
+    ```plaintext
+    原来的行为：
+    > XADD x 1 f1 v1
+    "1-0"
+    > XADD x 2 f1 v1
+    "2-0"
+    > XADD x 3 f1 v1
+    "3-0"
+    > XGROUP CREATE x grp 0
+    OK
+    > XREADGROUP GROUP grp Alice COUNT 2 STREAMS x >
+    1) 1) "x"
+       2) 1) 1) "1-0"
+             2) 1) "f1"
+                2) "v1"
+          2) 1) "2-0"
+             2) 1) "f1"
+                2) "v1"
+    > XDEL x 1 2
+    (integer) 2
+    > XCLAIM x grp Bob 0 0-99 1-0 1-99 2-0
+    1) (nil)
+    2) (nil)
+    > XPENDING x grp
+    1) (integer) 2
+    2) "1-0"
+    3) "2-0"
+    4) 1) 1) "Bob"
+          2) "2"
+
+    改动后：
+    > 到 XDEL 为止都相同
+    > XCLAIM x grp Bob 0 0-99 1-0 1-99 2-0
+    (empty array)
+    > XPENDING x grp
+    1) (integer) 0
+    2) (nil)
+    3) (nil)
+    4) (nil)
+    ```
+
+12. `XREADGROUP` 命令使用 block 参数，导致客户端因此阻塞时，如果 Stream key 被删除，会唤醒 block 的客户端。
+    -   社区 PR：[https://github.com/redis/redis/pull/10306](https://github.com/redis/redis/pull/10306)
+
+13. `SORT`/`SORT_RO` 命令在用户没有所有 key 的读权限时，使用 `BY`/`GET` 参数会报错。
+    -   社区 PR：[https://github.com/redis/redis/pull/10340](https://github.com/redis/redis/pull/10340)
+
+14. 当 replica 持久化失败时，会 panic 退出而不是继续执行主节点发来的命令。添加了配置项 `replica-ignore-disk-write-errors`，默认值为 0。设置为 1 会忽略持久化失败，和低版本行为一致。
+    -   社区 PR：[https://github.com/redis/redis/pull/10504](https://github.com/redis/redis/pull/10504)
+
+15. 移除了 Lua 中的 `print()` 函数，需要使用 `redis.log` 代替。
+    -   社区 PR：[https://github.com/redis/redis/pull/10651](https://github.com/redis/redis/pull/10651)
+
+16. `PFCOUNT` 和 `PUBLISH` 命令禁止在只读脚本中调用，因为它们可能产生复制流量。
+    -   社区 PR：[https://github.com/redis/redis/pull/10744](https://github.com/redis/redis/pull/10744)
+
+17. 命令的统计以子命令为单位，`INFO commandstats` 命令返回具体每个子命令的信息，比如现在会具体展示 `CLIENT LIST`、`CLIENT TRACKING` 命令的统计信息而不是笼统的展示 `CLIENT` 命令。
+    -   社区 PR：[https://github.com/redis/redis/pull/9504](https://github.com/redis/redis/pull/9504)
+
+18. 引入了 Multi Part AOF 机制，现在 AOF 文件夹中将会有 Meta、BASE AOF 和 INCR AOF 三种文件，文件夹路径由配置 `appenddirname` 决定。
+    -   社区 PR：[https://github.com/redis/redis/pull/9788](https://github.com/redis/redis/pull/9788)
+
+## 7.0 版本升级到 7.2 版本
+
+1.  开启了 Client Tracking 的客户端执行 Lua 脚本时，跟踪的 key 由 Lua 脚本声明的 key 变为脚本中的具体命令实际读取的 key。
+    -   社区 PR：[https://github.com/redis/redis/pull/11770](https://github.com/redis/redis/pull/11770)
+    
+    ```plaintext
+    原来的行为：
+    client A> CLIENT TRACKING on
+    client A> EVAL "redis.call('get', 'key2')" 2 key1 key2
+
+    client B> MSET key1 1 key2 2
+
+    client A> -> invalidate: 'key1'
+    client A> -> invalidate: 'key2'
+
+    改动后：
+    client A> CLIENT TRACKING on
+    client A> EVAL "redis.call('get', 'key2')" 2 key1 key2
+
+    client B> MSET key1 1 key2 2
+
+    client A> -> invalidate: 'key2'
+    ```
+
+2.  所有命令（包括一个 Lua 脚本内部）在执行过程中使用快照时间，所看到的时间不再变化，典型的例子是不能在一个 Lua 脚本中等待一个 key 过期。
+    -   社区 PR：[https://github.com/redis/redis/pull/10300](https://github.com/redis/redis/pull/10300)
+
+3.  ACL 不再移除冗余的权限变更记录，所有的操作记录都将被记录，影响 `ACL SAVE`, `ACL GETUSER`, `ACL LIST` 命令的输出。
+    -   社区 PR：[https://github.com/redis/redis/pull/11224](https://github.com/redis/redis/pull/11224)
+
+4.  `XREADGROUP` 和 `X[AUTO]CLAIM` 命令无论是否读取/声明成功，都会创建消费者。
+    -   社区 PR：[https://github.com/redis/redis/pull/11099](https://github.com/redis/redis/pull/11099)
+
+5.  `XREADGROUP` 命令在没有读取到消息时，会 reset 该 consumer 的 idle 字段，同时增加 active-time 字段记录 consumer 上次成功读取到消息的时间。
+    -   社区 PR：[https://github.com/redis/redis/pull/11099](https://github.com/redis/redis/pull/11099)
+
+6.  当阻塞命令解除阻塞时，会重新检查进行 ACL 权限、内存限制等检查，并根据解除阻塞后，重新执行命令时的情况区分错误码。
+    -   社区 PR：[https://github.com/redis/redis/pull/11012](https://github.com/redis/redis/pull/11012)
+    
+    ```plaintext
+    原来的行为：
+    ACL、OOM check --> block command --> unblock --> execute
+
+    改动后：
+    ACL、OOM check --> block command --> unblock --> ACL、OOM recheck --> execute
+    ```
+
+# 重要 Bugfix：
+
+## 5.0 版本
+
+1.  修复了判断 key 过期的逻辑，防止命令执行过程中，key 因为过期被删除导致的 UAF crash 问题（4.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/68d71d83](https://github.com/redis/redis/commit/68d71d83)
+
+2.  修复了当 AOF 刷盘策略设置为 everysec 时，有可能出现最后一秒内的数据没有落盘导致数据丢失的 Bug（4.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/c6b1252f](https://github.com/redis/redis/commit/c6b1252f)
+
+3.  修复了事务中的命令错误统计到了 exec 命令上的 Bug（4.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/d6aeca86](https://github.com/redis/redis/commit/d6aeca86)
+
+## 6.0 版本
+
+1.  修复了 `KEYS` 命令使用以 `\*\0` 开头的模式时，会返回所有 key 的 Bug（backport to 5.0，4.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/c7f75266](https://github.com/redis/redis/commit/c7f75266)
+
+2.  当字符串中包含 `\0` 时，尝试将该字符串转换为浮点类型的操作应该报错，影响 `HINCRBYFLOAT` 命令（5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/6fe55c2f](https://github.com/redis/redis/commit/6fe55c2f)
+
+3.  `-READONLY` 报错应该中断事务（5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/commit/8783304a](https://github.com/redis/redis/commit/8783304a)
+
+## 6.2 版本
+
+1.  `EXISTS` 命令不再改变 LRU，`OBJECT` 命令不会展示已经过期的 key 的信息。（backport to 6.0，5.0 及以下仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8016](https://github.com/redis/redis/pull/8016)
+
+2.  修复当从哈希表中随机挑选一个元素的操作只能支持 0 ~ 2^31 - 1 的范围，当哈希表元素超过 2^31 时，影响逐出、`RANDOMKEY`、`SRANDMEMBER` 等行为的公平性。（backport to 6.0，5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8133](https://github.com/redis/redis/pull/8133)
+
+3.  `SMOVE` 命令没有改变目标 key 时，不通知 `WATCH` 和 `CLIENT TRACKING`。（backport to 6.0，5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9244](https://github.com/redis/redis/pull/9244)
+
+4.  修复了在 pipeline 中使用超时的 Lua 脚本时，有可能导致服务端不再处理 pipeline 中后续的其它命令，直到该连接有新的消息。（6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8715](https://github.com/redis/redis/pull/8715)
+
+5.  `SCRIPT KILL` 能够终止 Lua 中的 pcall。原来如果 Lua 中一直在执行 pcall，那么 `SCRIPT KILL` 产生的 error 就会被 pcall 捕获，导致脚本不会停止，现在通过在 Lua VM 层面产生 error，来终止 Lua 执行。（6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8661](https://github.com/redis/redis/pull/8661)
+
+## 7.0 版本
+
+1.  修复了用户参数过大导致触发 Lua 栈溢出的 assert。（backport to 6.0，5.0 版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9809](https://github.com/redis/redis/pull/9809)
+
+2.  修复了使用 `list-compress-depth` 配置时可能出现的 crash。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9849](https://github.com/redis/redis/pull/9849)
+
+3.  修复了当单个 String/List 超过 4GB 时，开启 `rdbcompression` 配置生产 RDB 时会导致 RDB 损坏的问题。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9776](https://github.com/redis/redis/pull/9776)
+
+4.  修复了当向 Set/Hash 添加超过 2GB 大小的元素时，会导致 crash 的 Bug。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9916](https://github.com/redis/redis/pull/9916)
+
+5.  当设置极大或极小的过期时间，导致过期时间溢出时应该报错。（backport to 6.2，6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8287](https://github.com/redis/redis/pull/8287)
+
+6.  当 `DECRBY` 命令输入 `LLONG_MIN` 时应该报错而不是导致溢出。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9577](https://github.com/redis/redis/pull/9577)
+
+7.  修复了 ZSet 元素数量大于 `UINT32_MAX` 时，可能出现 rank 计算溢出。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9249](https://github.com/redis/redis/pull/9249)
+
+8.  修复了 Lua 中的写命令会无视 `CLIENT TRACKING NOLOOP` 的 Bug。（6.0 版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/11052](https://github.com/redis/redis/pull/11052)
+
+9.  修复了 `CLIENT TRACKING` 开启时，key 失效的 push 包有可能穿插在当前连接执行其它命令的回包之间（backport to 6.2，6.0 版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/11038](https://github.com/redis/redis/pull/11038), [https://github.com/redis/redis/pull/9422](https://github.com/redis/redis/pull/9422)
+
+10. 当 `WATCH` 的 key 在 `EXEC` 执行时已经过期，无论是否被删除，事务都应该失败。另外在事务执行期间，事务中 server 用于判断是否过期的时间戳不应该更新。（backport to 6.0，5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9194](https://github.com/redis/redis/pull/9194)
+
+11. 修复了 `SINTERSTORE` 命令操作的 key 类型不对时没有返回 `WRONGTYPE` 错误，在特殊情况下有可能导致目标 key 被删除的 Bug（backport to 6.0，5.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9032](https://github.com/redis/redis/pull/9032)
+
+12. 修复了客户端内存超过 `client-output-buffer-limit` 的 soft limit 后，如果一直没有流量，超过了 soft limit timeout 后仍然不会被断连接的 Bug。（backport to 6.2，6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/8833](https://github.com/redis/redis/pull/8833)
+
+13. 修复了 `XREADGROUP`, `XCLAIM`, `XAUTOCLAIM` 命令创建消费者时，没有发出 keyspace notification；`XGROUP DELCONSUMER` 命令删除不存在的消费者时，不应该发出 keyspace notification。（6.2 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/9263](https://github.com/redis/redis/pull/9263)
+
+14. 修复了 `GEO` 命令在 search 时，有可能遗漏掉比较靠近搜索边界的点的 Bug。（6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/10018](https://github.com/redis/redis/pull/10018)
+
+15. 修复了在 Lua 的返回值处理过程中，使用 metatable 时如果触发错误会导致 server crash 问题。（6.0 及以下版本仍有影响）
+    -   社区 PR：[https://github.com/redis/redis/pull/11032](https://github.com/redis/redis/pull/11032)
+
+16. 修复了以秒为单位的 Blocking 命令（比如 `BLPOP`/`BRPOP`）在 timeout 小于 0.001 秒时有可能被解析为 0 导致永久阻塞的 bug（6.2 及以下版本仍有影响）。
+    -   社区 PR：[https://github.com/redis/redis/pull/11688](https://github.com/redis/redis/pull/11688)
+
+17. 修复了恶意的 `KEYS`, `HRANDFIELD`, `SRANDMEMBER`, `ZRANDMEMBER` 命令可能导致 server hang 死，（`KEYS` 仍有可能在 6.2 及以下版本造成 server hang 死）。
+    -   社区 PR：[https://github.com/redis/redis/pull/11676](https://github.com/redis/redis/pull/11676)
+
+18. Lua 脚本安全性修复，禁止定义全局变量，所有的用户变量必须加 local 声明，否则直接报错。（全版本 backport，老脚本在升级小版本或大版本后均会报错）
+    -   社区 PR：https://github.com/redis/redis/pull/10651
+
+## 7.2 版本
+
+1.  修复了 `SRANDMEMBER`, `ZRANDMEMBER`, `HRANDFIELD` 命令在使用 `count` 参数时，有小概率死循环的 Bug（backport to 7.0，6.2 及以下版本仍有问题）
+    -   社区 PR：[https://github.com/redis/redis/pull/12276](https://github.com/redis/redis/pull/12276)
+
+2.  `HINCRBYFLOAT` 命令在解析 increment 参数失败后不会创建 key（backport to 6.0，5.0 及以下版本仍有问题）
+    -   社区 PR：[https://github.com/redis/redis/pull/11149](https://github.com/redis/redis/pull/11149)
+    -   命令文档：[https://redis.io/docs/latest/commands/hincrbyfloat/](https://redis.io/docs/latest/commands/hincrbyfloat/)
+
+3.  `LSET` 命令将 List 中大量的小元素换成大元素时，极端情况下可能导致 crash（7.0 版本仍有问题）
+    -   社区 PR：[https://github.com/redis/redis/pull/12955](https://github.com/redis/redis/pull/12955)
+    -   命令文档：[https://redis.io/docs/latest/commands/lset/](https://redis.io/docs/latest/commands/lset/)


### PR DESCRIPTION
Redis 在发布新版本时，会尽可能保持与低版本的兼容性。大多数情况下，我们都可以放心地进行版本升级来使用更稳定、功能更丰富的 Redis 服务，但仍有部分新特性、修复或优化会带来不同版本 Redis 的行为差异。

为了帮助用户快速评估大版本升级的风险，以及规避当前版本中可能触发的已知 Bug，我们阿里云 Tair 团队结合社区的发布说明、对 Redis 核心代码的理解以及在生产环境中的实际运营经验，撰写了这份兼容性报告。

本文档主要包含两方面的内容：

*   **用户视角的兼容性差异**：梳理了从 4.0 到 7.2 的大版本升级后，可能影响您现有应用的 Redis 行为变化。
*   **重要的 Bug 修复汇总**：整理了可能影响服务稳定性的关键 Bugfix 及其 backport 的情况。
